### PR TITLE
Emacs Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,25 @@ FILE PATH: /home/user/.config/Code/User/settings.json
 
 ## emacs
 
+```emacs-lisp
+(use-package lsp-mode
+  :ensure t)
+
+(use-package nix-mode
+  :ensure t
+  :hook
+  (nix-mode . lsp-deferred) ;; So that direnv integration with `envrc-mode' will work
+  :config
+  (setq lsp-nix-nixd-server-path "nixd")) ;; Note: make sure that nil is not in your $PATH
+
+;; For Tree Sitter
+(use-package nix-ts-mode
+  :ensure t
+  :mode "\\.nix\\'"
+  :hook
+  (nix-ts-mode . lsp-deferred) ;; So that envrc mode will work
+  :config
+  (setq lsp-nix-nixd-server-path "nixd")) ;; Note: make sure that nil is not in your $PATH
+```
+
 https://emacs-lsp.github.io/lsp-mode/page/lsp-nix/#installation


### PR DESCRIPTION
This is a basic emacs configuration that should Just Work™. Unfortunately there are no options available to configure nixd as of right now. I have [opened an issue on lsp-mode](https://github.com/emacs-lsp/lsp-mode/issues/4592) so hopefully that won't be the case for long. The other issue is that lsp-mode uses a priority system to decide which lsp server to use, with nil having higher precedence than nixd. This means that if both nil and nixd are in your PATH nil gets executed every time. This is a design flaw but I can't change anything about. Using direnv fixes this but I didn't include the setup for that because I though it was beyond the scope of the video.