### PR TITLE
Better Emacs config that works even if nil is in your PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,21 +74,32 @@ FILE PATH: /home/user/.config/Code/User/settings.json
 (use-package lsp-mode
   :ensure t)
 
+;; For Without Tree Sitter
 (use-package nix-mode
   :ensure t
   :hook
-  (nix-mode . lsp-deferred) ;; So that direnv integration with `envrc-mode' will work
+  (nix-mode . lsp-deferred)) ;; So that envrc mode will work
+
+(use-package nix-mode
+  :after lsp-mode
+  :custom
+  (lsp-disabled-clients '((nix-mode . nix-nil))) ;; Disable nil so that nixd will be used as lsp-server
   :config
-  (setq lsp-nix-nixd-server-path "nixd")) ;; Note: make sure that nil is not in your $PATH
+  (setq lsp-nix-nixd-server-path "nixd"))
 
 ;; For Tree Sitter
 (use-package nix-ts-mode
   :ensure t
   :mode "\\.nix\\'"
   :hook
-  (nix-ts-mode . lsp-deferred) ;; So that envrc mode will work
+  (nix-ts-mode . lsp-deferred)) ;; So that envrc mode will work
+
+(use-package nix-ts-mode
+  :after lsp-mode
+  :custom
+  (lsp-disabled-clients '((nix-ts-mode . nix-nil))) ;; Disable nil so that nixd will be used as lsp-server
   :config
-  (setq lsp-nix-nixd-server-path "nixd")) ;; Note: make sure that nil is not in your $PATH
+  (setq lsp-nix-nixd-server-path "nixd"))
 ```
 
 https://emacs-lsp.github.io/lsp-mode/page/lsp-nix/#installation


### PR DESCRIPTION
It also takes advantage of lazy loading and nix-mode will work even if lsp-mode isn't installed, making it resilent to changes elsewhere in the configuration. I have also tested it with the vanilla emacs package in nixpkgs and it worked so it is plug an play.

Sorry to make another pull request, this is the last one I swear!